### PR TITLE
chore: change devcontainer shell, move features to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,38 +1,72 @@
 FROM mcr.microsoft.com/devcontainers/php:1-8.2-bookworm
 
+# Add Node apt repository
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+
+# Add symfony CLI repository
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | bash
+
+# Add httpie apt repository
+RUN curl -SsL https://packages.httpie.io/deb/KEY.gpg | gpg --dearmor -o /usr/share/keyrings/httpie.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" | tee /etc/apt/sources.list.d/httpie.list > /dev/null
+
+# Add gh apt repository
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
 # Install additional OS packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
-    libxslt1-dev
-
-# Install MariaDB client
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y mariadb-client \ 
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-# Install httpie
-RUN curl -SsL https://packages.httpie.io/deb/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/httpie.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" | sudo tee /etc/apt/sources.list.d/httpie.list > /dev/null \
-    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y httpie \
+    && apt-get -y install \
+    curl \
+    fish \
+    gh \
+    httpie \
+    mariadb-client \
+    nodejs \
+    libxslt1-dev \
+    symfony-cli \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install php extensions
 RUN docker-php-ext-install mysqli pdo pdo_mysql xsl
 
-# Install symfony CLI
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
-RUN sudo apt install symfony-cli
+# Set fish as the default shell for the devcontainer user
+RUN echo "/usr/bin/fish" >> /etc/shells \
+    && chsh -s /usr/bin/fish vscode
 
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+# Install starship shell prompt
+RUN curl -sS https://starship.rs/install.sh | sh -s -- --yes
 
 # Run following commands as unprivileged user
 USER vscode
 # cd to home directory
 WORKDIR /home/vscode
 
+# Install composer
+RUN EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')" \
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" \
+    if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ] \
+    then \
+    >&2 echo 'ERROR: Invalid installer checksum' \
+    rm composer-setup.php \
+    exit 1 \
+    fi \
+    php composer-setup.php --quiet \
+    RESULT=$? \
+    rm composer-setup.php \
+    exit $RESULT
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
 # Add git bash completions
 RUN grep -qxF 'source /usr/share/bash-completion/completions/git' .bashrc || echo 'source /usr/share/bash-completion/completions/git' >> .bashrc
 # Prevent "dubious ownership" git error message
 RUN git config --global --add safe.directory /workspace
+
+# Set starship at fish init
+RUN mkdir -p /home/vscode/.config/fish \
+    && echo 'starship init fish | source' >> /home/vscode/.config/fish/config.fish

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,12 +14,7 @@
 		"mailcatcher:1025",
 	],
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		"ghcr.io/devcontainers-contrib/features/composer:1": {},
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "latest"
-		}
-	},
+	"features": {},
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -31,7 +26,7 @@
 		}
 	},
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
+	// "postCreateCommand": "",
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root",
 }

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -21,13 +21,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build the devcontainer
         run: |
           docker build \
             --file .devcontainer/Dockerfile \
             --tag devcontainer:latest \
+            --build-arg BUILDKIT_CACHE=/tmp/.buildx-cache \
             .
+
       - name: Run a command in the devcontainer
         run: |
-          docker run --rm my-devcontainer:latest bash -c "node --version && php bin/console --version"
-
+          docker run --rm devcontainer:latest bash -c "node --version && php bin/console --version"

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -39,4 +39,6 @@ jobs:
 
       - name: Run a command in the devcontainer
         run: |
-          docker run --rm devcontainer:latest bash -c "node --version && php bin/console --version"
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \  # Mount the repository to /workspace
+            devcontainer:latest bash -c "npm --version && php /workspace/bin/console --version"

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -9,6 +9,7 @@ on:
       - master
   schedule:
     - cron: "0 0 * * *" # This will run every day at midnight UTC
+  workflow_dispatch:  # Enable manual triggering of the workflow
 
 jobs:
   build:
@@ -35,8 +36,10 @@ jobs:
           file: .devcontainer/Dockerfile
           push: true
           tags: localhost:5000/cognac/devcontainer:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # on pull_request save time by caching layers between commits
+          # otherwise, check build thoroughly so disable cache
+          cache-from: ${{ github.event_name == 'pull_request' && 'type=gha' || '' }}
+          cache-to: ${{ github.event_name == 'pull_request' && 'type=gha,mode=max' || '' }}
 
       - name: Run a command in the devcontainer
         run: |

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,0 +1,33 @@
+name: Check DevContainer Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * *" # This will run every day at midnight UTC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build the devcontainer
+        run: |
+          docker build \
+            --file .devcontainer/Dockerfile \
+            --tag devcontainer:latest \
+            .
+      - name: Run a command in the devcontainer
+        run: |
+          docker run --rm my-devcontainer:latest bash -c "node --version && php bin/console --version"
+

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -13,32 +13,32 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: docker/setup-buildx-action@v3
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          driver-opts: network=host
 
       - name: Build the devcontainer
-        run: |
-          docker build \
-            --file .devcontainer/Dockerfile \
-            --tag devcontainer:latest \
-            --build-arg BUILDKIT_CACHE=/tmp/.buildx-cache \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .devcontainer/Dockerfile
+          push: true
+          tags: localhost:5000/cognac/devcontainer:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run a command in the devcontainer
         run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \  # Mount the repository to /workspace
-            devcontainer:latest bash -c "npm --version && php /workspace/bin/console --version"
+          docker run --rm localhost:5000/cognac/devcontainer:latest \
+            bash -c "node --version && php --version"


### PR DESCRIPTION
This PR moves back the devcontainer features to the Dockerfile directly.

For subjective reasons I believe it is more robust that the devcontainer definition includes all the required tools rather than for it to depend on the IDE implementing the spec. TBD if we keep it that way or end up reverting, or if we maintain our own fleet of features separately.

It also adds some convenience tools such as the `gh` CLI, `fish` shell, and `starship` shell prompt.

To ensure that the devcontainer is kept maintained, this PR also adds a Github Action that builds the container on schedule and push / PR.